### PR TITLE
Review panel sab combined

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,7 @@
             "skipFiles": [
                 "<node_internals>/**",
                 "**/node_modules/**",
+                "**/clarity.js",
             ]
         },
         {
@@ -24,6 +25,7 @@
             "skipFiles": [
                 "<node_internals>/**",
                 "**/node_modules/**",
+                "**/clarity.js",
             ]
         },
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,19 +5,26 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "name": "(survey)Launch Chrome against localhost",
             "url": "http://localhost:8200/test-survey",
-            "webRoot": "${workspaceFolder}/apps/survey/"
+            "webRoot": "${workspaceFolder}/apps/survey/",
+            "skipFiles": [
+                "<node_internals>/**",
+                "**/node_modules/**",
+            ]
         },
         {
-            "type": "pwa-chrome",
+            "type": "chrome",
             "request": "launch",
             "name": "(admin) Launch Chrome against localhost",
             "url": "http://localhost:8100",
-            "webRoot": "${workspaceFolder}/apps/admin/"
-        }
-
+            "webRoot": "${workspaceFolder}/apps/admin/",
+            "skipFiles": [
+                "<node_internals>/**",
+                "**/node_modules/**",
+            ]
+        },
     ]
 }

--- a/apps/admin/src/components/lists/options-list.vue
+++ b/apps/admin/src/components/lists/options-list.vue
@@ -33,6 +33,13 @@
             variant="outlined"
           />
           <v-text-field
+            v-model="option.shortLabel"
+            density="compact"
+            hide-details="auto"
+            :label="$t('common.options.shortLabel')"
+            variant="outlined"
+          />
+          <v-text-field
             v-model="option.value"
             density="compact"
             hide-details="auto"
@@ -112,7 +119,7 @@ const optionValueRules = computed<RuleCallback[]>(() => [...defaultValueRules, .
 
 function add() {
   const size = currentOptions.value.length + 1;
-  currentOptions.value.push({ id: size, label: `label-${size}`, value: props.numeric ? size : `value-${size}` });
+  currentOptions.value.push({ id: size, label: `label-${size}`, shortLabel: `shortLabel-${size}`, value: props.numeric ? size : `value-${size}` });
 };
 
 function remove(index: number) {

--- a/apps/admin/src/components/prompts/standard/same-as-before-prompt.vue
+++ b/apps/admin/src/components/prompts/standard/same-as-before-prompt.vue
@@ -1,9 +1,22 @@
 <template>
-  <v-tabs-window-item key="options" value="options" />
+  <v-tabs-window-item key="options" value="options">
+    <v-row class="ml-2">
+      <v-col cols="12" md="6">
+        <v-switch
+          hide-details="auto"
+          :label="$t('survey-schemes.prompts.same-as-before-prompt.skipToSAB')"
+          :model-value="skipToSAB"
+          @update:model-value="update('skipToSAB', $event)"
+        />
+      </v-col>
+    </v-row>
+  </v-tabs-window-item>
 </template>
 
 <script lang="ts">
+import type { PropType } from 'vue';
 import { defineComponent } from 'vue';
+import type { Prompts } from '@intake24/common/prompts';
 
 import { basePrompt } from '../partials';
 
@@ -11,6 +24,12 @@ export default defineComponent({
   name: 'SameAsBeforePrompt',
 
   mixins: [basePrompt],
+  props: {
+    skipToSAB: {
+      type: Boolean as PropType<Prompts['same-as-before-prompt']['skipToSAB']>,
+      required: true,
+    },
+  },
 });
 </script>
 

--- a/apps/survey/src/components/handlers/standard/SameAsBeforePromptHandler.vue
+++ b/apps/survey/src/components/handlers/standard/SameAsBeforePromptHandler.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script lang="ts" setup>
-import { onMounted, ref } from 'vue';
+import { onMounted } from 'vue';
 import { SameAsBeforePrompt } from '@intake24/survey/components/prompts/standard';
 import { useSameAsBefore, useSurvey } from '@intake24/survey/stores';
 import { getEntityId } from '@intake24/survey/util';
@@ -29,19 +29,13 @@ const survey = useSurvey();
 
 const sabFood = useSameAsBefore().getItem(survey.localeId, code);
 
-interface SabOptions {
-  [key: string]: boolean;
-}
-const sabOptions = ref<SabOptions>({});
-
-function onSabOptionsUpdate(newSabOptions: SabOptions): void {
-  console.debug('Received sabOptions from child:', newSabOptions);
-  sabOptions.value = newSabOptions;
-  // Remove portion size and portion size method if serving checkbox is false
-  if (!sabOptions.value.serving && sabFood?.food?.portionSize) {
+function onSabOptionsUpdate(sabOptions: Record<string, boolean>): void {
+  console.debug('Received sabOptions from child:', sabOptions);
+  if (!sabOptions.serving && sabFood?.food?.portionSize) {
     sabFood.food.portionSize = null;
     sabFood.food.portionSizeMethodIndex = null;
-    console.debug('sabFood.food.portionSize cleared');
+    console.debug('Portion size and method are removed as SAB serving checkbox being false');
+
     if (Array.isArray(sabFood.food.flags)) {
       sabFood.food.flags = sabFood.food.flags.filter(
         (flag: string) =>
@@ -51,46 +45,36 @@ function onSabOptionsUpdate(newSabOptions: SabOptions): void {
       console.debug('Flags updated:', sabFood.food.flags);
     }
   }
-  // Remove portion size if leftovers checkbox is false
-  if (!sabOptions.value.leftovers && sabFood?.food?.portionSize) {
+  if (!sabOptions.leftovers && sabFood?.food?.portionSize) {
+    console.debug('Removing portion size due to SAB leftovers checkbox being false');
     sabFood.food.portionSize = null;
-    console.debug('sabFood.food.portionSize cleared');
     if (Array.isArray(sabFood.food.flags)) {
       sabFood.food.flags = sabFood.food.flags.filter(
         (flag: string) =>
           flag !== 'portion-size-option-complete'
           && flag !== 'portion-size-method-complete',
       );
-      console.debug('Flags updated:', sabFood.food.flags);
+      console.debug('portion-size-option-complete and portion-size-method-complete flags removed:', sabFood.food.flags);
     }
   }
-  // Keep or remove linked foods if checkbox for linked foods is false
-  // loop through sabFood.food.linkedFoods, match id with the key of sabOptions.value
-  // when a match is found, check if the value is false, if so, remove the linked food
-  // when a match is found and the value is true, keep the linked food
   if (sabFood?.food?.linkedFoods) {
+    console.debug('Removing linked foods if is explicitly unchecked in SAB options');
+    const numberOfLinkedFood = sabFood.food.linkedFoods.length;
+
     sabFood.food.linkedFoods = sabFood.food.linkedFoods.filter(
-      (linkedFood) => {
-        const key = linkedFood.id;
-        if (sabOptions.value[key] === false) {
-          console.debug(`Removing linked food with id ${key} because checkbox is false`);
-          return false; // Remove this linked food
-        }
-        console.debug(`Keeping linked food with id ${key} because checkbox is true`);
-        return true; // Keep this linked food
-      },
+      linkedFood => !(sabOptions[linkedFood.id] === false),
     );
-  }
-  // Update custom prompt answers if checkbox for custom prompts
-  // if true, change prompt id to prompt name, otherwise remove them
-  if (sabOptions.value.customPromptAnswers) {
-    console.log('Updating custom prompts for sabFood');
-  }
-  else if (sabOptions.value.customPromptAnswers === false && sabFood?.food?.customPromptAnswers) {
-    console.log('Removing custom prompts for sabFood');
-    if (sabFood.food.customPromptAnswers && typeof sabFood.food.customPromptAnswers === 'object') {
-      sabFood.food.customPromptAnswers = {};
+    console.debug('Linked foods updated:', sabFood.food.linkedFoods);
+    if (sabFood.food.linkedFoods.length < numberOfLinkedFood && Array.isArray(sabFood.food.flags)) {
+      sabFood.food.flags = sabFood.food.flags.filter(
+        (flag: string) => flag !== 'associated-foods-complete',
+      );
+      console.debug('associated-foods-complete flag removed:', sabFood.food.flags);
     }
+  }
+  if (sabOptions.customPromptAnswers === false && sabFood?.food?.customPromptAnswers) {
+    sabFood.food.customPromptAnswers = {};
+    console.debug('Custom prompt answers removed as SAB custom prompt answers checkbox is explicitly set to false');
   }
 }
 function sabAction(type: 'notSame' | 'same') {

--- a/apps/survey/src/components/handlers/standard/SameAsBeforePromptHandler.vue
+++ b/apps/survey/src/components/handlers/standard/SameAsBeforePromptHandler.vue
@@ -68,7 +68,8 @@ function onSabOptionsUpdate(sabOptions: Record<string, boolean>): void {
 
   if (sabOptions.customPromptAnswers === false && updatedSabFood?.food?.customPromptAnswers) {
     updatedSabFood.food.customPromptAnswers = {};
-    console.debug('Custom prompt answers removed as SAB custom prompt answers checkbox is explicitly set to false');
+    delete updatedSabFood.food.external;
+    console.debug('Custom prompt answers and external food removed as SAB custom prompt answers checkbox is explicitly set to false');
   }
 }
 

--- a/apps/survey/src/components/handlers/standard/SameAsBeforePromptHandler.vue
+++ b/apps/survey/src/components/handlers/standard/SameAsBeforePromptHandler.vue
@@ -3,11 +3,12 @@
     v-if="sabFood"
     v-bind="{ food, meal, prompt, sabFood, section }"
     @action="action"
+    @update:sab-options="onSabOptionsUpdate"
   />
 </template>
 
 <script lang="ts" setup>
-import { onMounted } from 'vue';
+import { onMounted, ref } from 'vue';
 import { SameAsBeforePrompt } from '@intake24/survey/components/prompts/standard';
 import { useSameAsBefore, useSurvey } from '@intake24/survey/stores';
 import { getEntityId } from '@intake24/survey/util';
@@ -28,6 +29,59 @@ const survey = useSurvey();
 
 const sabFood = useSameAsBefore().getItem(survey.localeId, code);
 
+interface SabOptions {
+  [key: string]: boolean;
+}
+const sabOptions = ref<SabOptions>({});
+
+function onSabOptionsUpdate(newSabOptions: SabOptions): void {
+  console.debug('Received sabOptions from child:', newSabOptions);
+  sabOptions.value = newSabOptions;
+  // Remove portion size and portion size method if serving checkbox is false
+  if (!sabOptions.value.serving && sabFood?.food?.portionSize) {
+    sabFood.food.portionSize = null;
+    sabFood.food.portionSizeMethodIndex = null;
+    console.debug('sabFood.food.portionSize cleared');
+    if (Array.isArray(sabFood.food.flags)) {
+      sabFood.food.flags = sabFood.food.flags.filter(
+        (flag: string) =>
+          flag !== 'portion-size-option-complete'
+          && flag !== 'portion-size-method-complete',
+      );
+      console.debug('Flags updated:', sabFood.food.flags);
+    }
+  }
+  // Remove portion size if leftovers checkbox is false
+  if (!sabOptions.value.leftovers && sabFood?.food?.portionSize) {
+    sabFood.food.portionSize = null;
+    console.debug('sabFood.food.portionSize cleared');
+    if (Array.isArray(sabFood.food.flags)) {
+      sabFood.food.flags = sabFood.food.flags.filter(
+        (flag: string) =>
+          flag !== 'portion-size-option-complete'
+          && flag !== 'portion-size-method-complete',
+      );
+      console.debug('Flags updated:', sabFood.food.flags);
+    }
+  }
+  // Keep or remove linked foods if checkbox for linked foods is false
+  // loop through sabFood.food.linkedFoods, match id with the key of sabOptions.value
+  // when a match is found, check if the value is false, if so, remove the linked food
+  // when a match is found and the value is true, keep the linked food
+  if (sabFood?.food?.linkedFoods) {
+    sabFood.food.linkedFoods = sabFood.food.linkedFoods.filter(
+      (linkedFood) => {
+        const key = linkedFood.id;
+        if (sabOptions.value[key] === false) {
+          console.debug(`Removing linked food with id ${key} because checkbox is false`);
+          return false; // Remove this linked food
+        }
+        console.debug(`Keeping linked food with id ${key} because checkbox is true`);
+        return true; // Keep this linked food
+      },
+    );
+  }
+}
 function sabAction(type: 'notSame' | 'same') {
   if (type === 'same' && sabFood) {
     const { id, ...update } = sabFood.food;

--- a/apps/survey/src/components/handlers/standard/SameAsBeforePromptHandler.vue
+++ b/apps/survey/src/components/handlers/standard/SameAsBeforePromptHandler.vue
@@ -81,6 +81,17 @@ function onSabOptionsUpdate(newSabOptions: SabOptions): void {
       },
     );
   }
+  // Update custom prompt answers if checkbox for custom prompts
+  // if true, change prompt id to prompt name, otherwise remove them
+  if (sabOptions.value.customPromptAnswers) {
+    console.log('Updating custom prompts for sabFood');
+  }
+  else if (sabOptions.value.customPromptAnswers === false && sabFood?.food?.customPromptAnswers) {
+    console.log('Removing custom prompts for sabFood');
+    if (sabFood.food.customPromptAnswers && typeof sabFood.food.customPromptAnswers === 'object') {
+      sabFood.food.customPromptAnswers = {};
+    }
+  }
 }
 function sabAction(type: 'notSame' | 'same') {
   if (type === 'same' && sabFood) {

--- a/apps/survey/src/components/handlers/standard/SameAsBeforePromptHandler.vue
+++ b/apps/survey/src/components/handlers/standard/SameAsBeforePromptHandler.vue
@@ -28,63 +28,58 @@ const {
 const survey = useSurvey();
 
 const sabFood = useSameAsBefore().getItem(survey.localeId, code);
-
+const updatedSabFood = {
+  ...(sabFood ?? {}),
+  food: {
+    ...(sabFood?.food ?? {}),
+    portionSize: sabFood?.food?.portionSize ? { ...sabFood.food.portionSize } : undefined,
+    portionSizeMethodIndex: sabFood?.food?.portionSizeMethodIndex ?? undefined,
+    linkedFoods: sabFood?.food?.linkedFoods ? [...sabFood.food.linkedFoods] : [],
+    customPromptAnswers: sabFood?.food?.customPromptAnswers ? { ...sabFood.food.customPromptAnswers } : {},
+    flags: sabFood?.food?.flags ? [...sabFood.food.flags] : [],
+  },
+};
 function onSabOptionsUpdate(sabOptions: Record<string, boolean>): void {
   console.debug('Received sabOptions from child:', sabOptions);
-  if (!sabOptions.serving && sabFood?.food?.portionSize) {
-    sabFood.food.portionSize = null;
-    sabFood.food.portionSizeMethodIndex = null;
-    console.debug('Portion size and method are removed as SAB serving checkbox being false');
-
-    if (Array.isArray(sabFood.food.flags)) {
-      sabFood.food.flags = sabFood.food.flags.filter(
+  if (!sabOptions.portionSize && updatedSabFood?.food?.portionSize) {
+    updatedSabFood.food.portionSizeMethodIndex = undefined;
+    updatedSabFood.food.portionSize = undefined;
+    console.debug('PortionSize and Portion method index is removed as SAB prompt checkbox is explicitly set to false');
+    if (Array.isArray(updatedSabFood.food.flags)) {
+      updatedSabFood.food.flags = updatedSabFood.food.flags.filter(
         (flag: string) =>
           flag !== 'portion-size-option-complete'
           && flag !== 'portion-size-method-complete',
       );
-      console.debug('Flags updated:', sabFood.food.flags);
+      console.debug('portion-size-option-complete and portion-size-method-complete flag removed:', updatedSabFood.food.flags);
     }
   }
-  if (!sabOptions.leftovers && sabFood?.food?.portionSize) {
-    console.debug('Removing portion size due to SAB leftovers checkbox being false');
-    sabFood.food.portionSize = null;
-    if (Array.isArray(sabFood.food.flags)) {
-      sabFood.food.flags = sabFood.food.flags.filter(
-        (flag: string) =>
-          flag !== 'portion-size-option-complete'
-          && flag !== 'portion-size-method-complete',
-      );
-      console.debug('portion-size-option-complete and portion-size-method-complete flags removed:', sabFood.food.flags);
-    }
-  }
-  if (sabFood?.food?.linkedFoods) {
-    console.debug('Removing linked foods if is explicitly unchecked in SAB options');
-    const numberOfLinkedFood = sabFood.food.linkedFoods.length;
 
-    sabFood.food.linkedFoods = sabFood.food.linkedFoods.filter(
-      linkedFood => !(sabOptions[linkedFood.id] === false),
-    );
-    console.debug('Linked foods updated:', sabFood.food.linkedFoods);
-    if (sabFood.food.linkedFoods.length < numberOfLinkedFood && Array.isArray(sabFood.food.flags)) {
-      sabFood.food.flags = sabFood.food.flags.filter(
+  if (!sabOptions.linkedFoods && updatedSabFood?.food?.linkedFoods) {
+    updatedSabFood.food.linkedFoods = [];
+    console.debug('Linked foods are removed as SAB prompt linked foods checkbox is explicitly set to false');
+    if (Array.isArray(updatedSabFood.food.flags)) {
+      updatedSabFood.food.flags = updatedSabFood.food.flags.filter(
         (flag: string) => flag !== 'associated-foods-complete',
       );
-      console.debug('associated-foods-complete flag removed:', sabFood.food.flags);
+      console.debug('associated-foods-complete flag removed:', updatedSabFood.food.flags);
     }
   }
-  if (sabOptions.customPromptAnswers === false && sabFood?.food?.customPromptAnswers) {
-    sabFood.food.customPromptAnswers = {};
+
+  if (sabOptions.customPromptAnswers === false && updatedSabFood?.food?.customPromptAnswers) {
+    updatedSabFood.food.customPromptAnswers = {};
     console.debug('Custom prompt answers removed as SAB custom prompt answers checkbox is explicitly set to false');
   }
 }
+
 function sabAction(type: 'notSame' | 'same') {
-  if (type === 'same' && sabFood) {
-    const { id, ...update } = sabFood.food;
+  if (type === 'same' && updatedSabFood.food) {
+    const { id, ...update } = updatedSabFood.food;
     survey.updateFood({
       foodId,
       update: {
         ...update,
-        linkedFoods: update.linkedFoods.map(linkedFood => ({
+        linkedFoods: update.linkedFoods?.map(linkedFood => ({
           ...linkedFood,
           id: getEntityId(),
         })),

--- a/apps/survey/src/components/layouts/meal-list/desktop/food-item.vue
+++ b/apps/survey/src/components/layouts/meal-list/desktop/food-item.vue
@@ -5,8 +5,11 @@
       link
       @click="action('selectFood', food.id)"
     >
-      <v-list-item-title class="text-body-2 text-wrap">
-        {{ foodName }}
+      <v-list-item-title class="text-body-2 text-wrap d-flex flex-column">
+        <span class="food-name">{{ foodName }}</span>
+        <span v-if="customPromptAnswerLabels" class="text-caption text-grey">
+          {{ customPromptAnswerLabels }}
+        </span>
       </v-list-item-title>
       <template #append>
         <v-list-item-action class="d-flex flex-row me-4">
@@ -60,9 +63,11 @@
 
 <script lang="ts">
 import type { PropType } from 'vue';
-import { defineComponent } from 'vue';
+import { computed, defineComponent } from 'vue';
 
 import type { FoodState, MealState } from '@intake24/common/surveys';
+import { useI18n } from '@intake24/i18n';
+import { useSurvey } from '@intake24/survey/stores';
 
 import { useFoodItem } from '../use-food-item';
 import ContextMenu from './context-menu.vue';
@@ -92,9 +97,40 @@ export default defineComponent({
   },
 
   setup(props, ctx) {
+    const { i18n: { locale } } = useI18n();
+    const survey = useSurvey();
     const { action, foodName, isPortionSizeComplete, menu } = useFoodItem(props, ctx);
 
-    return { action, foodName, isPortionSizeComplete, menu };
+    const customPromptAnswerLabels = computed(() => {
+      if (!props.food.customPromptAnswers || Object.keys(props.food.customPromptAnswers).length === 0) {
+        return '';
+      }
+      const foodPrompts = survey.foodPrompts;
+      const answers: string[] = [];
+      Object.entries(props.food.customPromptAnswers).forEach(([promptId, answer]) => {
+        const prompt = foodPrompts.find(p => p.id === promptId);
+        let displayText = '';
+        // Handle different prompt types
+        if (prompt && 'options' in prompt && prompt.options) {
+          const options = prompt.options[locale.value] || prompt.options.en || [];
+          if (Array.isArray(answer)) {
+            // Multiple selection
+            const labels = answer.map(value =>
+              options.find(opt => opt.value === value)?.shortLabel || options.find(opt => opt.value === value)?.label || value,
+            );
+            displayText = labels.join(', ');
+          }
+          else {
+            // Single selection
+            displayText = options.find(opt => opt.value === answer)?.shortLabel || options.find(opt => opt.value === answer)?.label || '';
+          }
+        }
+        if (displayText.trim())
+          answers.push(displayText);
+      });
+      return answers.join(', ');
+    });
+    return { action, foodName, isPortionSizeComplete, menu, customPromptAnswerLabels };
   },
 });
 </script>

--- a/apps/survey/src/components/layouts/meal-list/desktop/food-item.vue
+++ b/apps/survey/src/components/layouts/meal-list/desktop/food-item.vue
@@ -116,13 +116,17 @@ export default defineComponent({
           if (Array.isArray(answer)) {
             // Multiple selection
             const labels = answer.map(value =>
-              options.find(opt => opt.value === value)?.shortLabel || options.find(opt => opt.value === value)?.label || value,
+              options.find(opt => opt.value === value)?.shortLabel
+              ?? options.find(opt => opt.value === value)?.label
+              ?? (value || '').toString(),
             );
             displayText = labels.join(', ');
           }
           else {
             // Single selection
-            displayText = options.find(opt => opt.value === answer)?.shortLabel || options.find(opt => opt.value === answer)?.label || '';
+            displayText = options.find(opt => opt.value === answer)?.shortLabel
+              ?? options.find(opt => opt.value === answer)?.label
+              ?? (answer || '').toString();
           }
         }
         if (displayText.trim())

--- a/apps/survey/src/components/layouts/meal-list/desktop/food-item.vue
+++ b/apps/survey/src/components/layouts/meal-list/desktop/food-item.vue
@@ -31,17 +31,17 @@
             <template #activator="{ props }">
               <v-icon
 
-                :color="isPortionSizeComplete ? 'green darken-2' : undefined"
+                :color="isPortionSizeComplete && isCustomPromptComplete ? 'green darken-2' : undefined"
                 size="small"
                 v-bind="props"
               >
-                {{ isPortionSizeComplete ? '$ok' : '$question' }}
+                {{ isPortionSizeComplete && isCustomPromptComplete ? '$ok' : '$question' }}
               </v-icon>
             </template>
             <span>
               {{
                 $t(
-                  `recall.menu.food.${food.type}.${isPortionSizeComplete ? 'complete' : 'incomplete'}`,
+                  `recall.menu.food.${food.type}.${isPortionSizeComplete && isCustomPromptComplete ? 'complete' : 'incomplete'}`,
                 )
               }}
             </span>
@@ -99,7 +99,7 @@ export default defineComponent({
   setup(props, ctx) {
     const { i18n: { locale } } = useI18n();
     const survey = useSurvey();
-    const { action, foodName, isPortionSizeComplete, menu } = useFoodItem(props, ctx);
+    const { action, foodName, isPortionSizeComplete, isCustomPromptComplete, menu } = useFoodItem(props, ctx);
 
     const customPromptAnswerLabels = computed(() => {
       if (!props.food.customPromptAnswers || Object.keys(props.food.customPromptAnswers).length === 0) {
@@ -130,7 +130,7 @@ export default defineComponent({
       });
       return answers.join(', ');
     });
-    return { action, foodName, isPortionSizeComplete, menu, customPromptAnswerLabels };
+    return { action, foodName, isPortionSizeComplete, isCustomPromptComplete, menu, customPromptAnswerLabels };
   },
 });
 </script>

--- a/apps/survey/src/components/layouts/meal-list/mobile/food-item.vue
+++ b/apps/survey/src/components/layouts/meal-list/mobile/food-item.vue
@@ -120,13 +120,17 @@ export default defineComponent({
           if (Array.isArray(answer)) {
             // Multiple selection
             const labels = answer.map(value =>
-              options.find(opt => opt.value === value)?.shortLabel || options.find(opt => opt.value === value)?.label || value,
+              options.find(opt => opt.value === value)?.shortLabel
+              ?? options.find(opt => opt.value === value)?.label
+              ?? (value || '').toString(),
             );
             displayText = labels.join(', ');
           }
           else {
             // Single selection
-            displayText = options.find(opt => opt.value === answer)?.shortLabel || options.find(opt => opt.value === answer)?.label || '';
+            displayText = options.find(opt => opt.value === answer)?.shortLabel
+              ?? options.find(opt => opt.value === answer)?.label
+              ?? (answer || '').toString();
           }
         }
         if (displayText.trim())

--- a/apps/survey/src/components/layouts/meal-list/mobile/food-item.vue
+++ b/apps/survey/src/components/layouts/meal-list/mobile/food-item.vue
@@ -33,8 +33,8 @@
             <template #activator="{ props }">
               <v-icon
                 v-bind="props"
-                :color="isPortionSizeComplete ? 'green darken-2' : undefined"
-                :icon="isPortionSizeComplete ? '$ok' : '$question'"
+                :color="isPortionSizeComplete && isCustomPromptComplete ? 'green darken-2' : undefined"
+                :icon="isPortionSizeComplete && isCustomPromptComplete ? '$ok' : '$question'"
                 size="small"
               />
             </template>
@@ -103,7 +103,7 @@ export default defineComponent({
   setup(props, ctx) {
     const { i18n: { locale } } = useI18n();
     const survey = useSurvey();
-    const { action, foodName, isPortionSizeComplete, menu } = useFoodItem(props, ctx);
+    const { action, foodName, isPortionSizeComplete, isCustomPromptComplete, menu } = useFoodItem(props, ctx);
 
     const customPromptAnswerLabels = computed(() => {
       if (!props.food.customPromptAnswers || Object.keys(props.food.customPromptAnswers).length === 0) {
@@ -144,6 +144,7 @@ export default defineComponent({
       isPortionSizeComplete,
       menu,
       customPromptAnswerLabels,
+      isCustomPromptComplete,
       updateContextId,
     };
   },

--- a/apps/survey/src/components/layouts/meal-list/use-food-item.ts
+++ b/apps/survey/src/components/layouts/meal-list/use-food-item.ts
@@ -5,7 +5,8 @@ import type { FoodActionType, MealActionType } from '@intake24/common/prompts';
 import type { FoodState, MealState } from '@intake24/common/surveys';
 import { useI18n } from '@intake24/i18n';
 import { useFoodUtils } from '@intake24/survey/composables';
-import { foodComplete, foodPortionSizeComplete } from '@intake24/survey/util';
+import { useSurvey } from '@intake24/survey/stores';
+import { customPromptComplete, foodComplete, foodPortionSizeComplete } from '@intake24/survey/util';
 
 export type MenuItem = {
   name: string;
@@ -23,8 +24,13 @@ export type UseFoodItemProps = {
 export function useFoodItem(props: UseFoodItemProps, { emit }: Pick<SetupContext<'action'[]>, 'emit'>) {
   const { i18n: { t } } = useI18n();
   const { foodName } = useFoodUtils(props);
+  const survey = useSurvey();
 
   const isPortionSizeComplete = computed(() => foodPortionSizeComplete(props.food));
+
+  const isCustomPromptComplete = computed(() => {
+    return customPromptComplete(survey, props.meal, props.food, survey.foodPrompts);
+  });
 
   const menu = computed(() =>
     (
@@ -54,5 +60,5 @@ export function useFoodItem(props: UseFoodItemProps, { emit }: Pick<SetupContext
     emit('action', type, id);
   };
 
-  return { action, foodName, isPortionSizeComplete, menu };
+  return { action, foodName, isPortionSizeComplete, isCustomPromptComplete, menu };
 }

--- a/apps/survey/src/components/prompts/standard/SameAsBeforePrompt.vue
+++ b/apps/survey/src/components/prompts/standard/SameAsBeforePrompt.vue
@@ -42,7 +42,7 @@
           </v-list-item>
         </v-list>
         <v-list v-if="linkedFoods.length" class="px-4" color="grey-lighten-4">
-          <v-list-subheader>hadwitdh-{{ promptI18n.hadWith }}</v-list-subheader>
+          <v-list-subheader>{{ promptI18n.hadWith }}</v-list-subheader>
           <v-divider />
           <v-list-item v-for="linkedFood in linkedFoods" :key="linkedFood.id" class="ps-0" density="compact">
             <v-checkbox
@@ -54,15 +54,17 @@
             />
           </v-list-item>
         </v-list>
-        <v-list v-if="customPromptAnswers.length" class="px-4" color="grey-lighten-4">
-          <v-list-subheader>Further information</v-list-subheader>
-          <v-divider />
-          <v-list-item v-for="(answer, index) in customPromptAnswers" :key="index" class="ps-0" density="compact">
-            <template #prepend>
-              <v-icon icon="fas fa-caret-right" />
-            </template>
-            <v-list-item-title>{{ answer }}</v-list-item-title>
-          </v-list-item>
+        <v-list v-if="customPromptAnswers && Object.keys(customPromptAnswers).length > 0" class="px-4" color="grey-lighten-4">
+          <v-list v-for="(customPromptAnswer, index) in customPromptAnswers" :key="index" class="px-4" color="grey-lighten-4">
+            <v-list-subheader>{{ promptNames[index] || '' }}</v-list-subheader>
+            <v-divider />
+            <v-list-item v-for="(answer, answerIdx) in customPromptAnswer" :key="answerIdx" class="ps-0" density="compact">
+              <template #prepend>
+                <v-icon icon="fas fa-caret-right" />
+              </template>
+              <v-list-item-title>{{ answer }}</v-list-item-title>
+            </v-list-item>
+          </v-list>
           <v-checkbox
             v-model="sabOptions.customPromptAnswers"
             class="custom-checkbox"
@@ -162,10 +164,7 @@ function getPortionWeight(food: EncodedFood) {
 
 function onSame() {
   console.debug('onSame action triggered');
-  console.debug('sabOptions.serving:', sabOptions.value.serving);
-  console.debug('sabOptions.leftovers:', sabOptions.value.leftovers);
-  // console.debug('sabOptions.noAddedFoods:', sabOptions.value.noAddedFoods);
-  console.debug('sabOptions.quantity:', sabOptions.value.quantity);
+  console.debug('sabOptions:', sabOptions.value);
 
   emit('update:sabOptions', { ...sabOptions.value }); // emit a copy to parent
   action('same');
@@ -208,8 +207,32 @@ const linkedFoods = computed(() =>
 );
 
 const customPromptAnswers = computed(() => {
-  const answers = props.sabFood.food.customPromptAnswers?.['sab-checkbox-list-prompt'];
-  return Array.isArray(answers) ? answers.map(answer => answer) : [];
+  const answers = props.sabFood.food.customPromptAnswers;
+  if (!answers) {
+    console.debug('No custom prompt answers found');
+    return {};
+  }
+  // delete null attributes in answers
+  const filteredAnswers = Object.fromEntries(
+    Object.entries(answers).filter(([_, value]) => value !== null),
+  );
+  return filteredAnswers;
+});
+
+const promptNames = computed(() => {
+  const idNameMap = survey.parameters?.surveyScheme.prompts.meals.foods.reduce(
+    (acc: Record<string, string>, item: { id: string; name: string }) => {
+      acc[item.id] = item.name;
+      return acc;
+    },
+    {},
+  );
+  if (!idNameMap) {
+    console.debug('No prompt names found');
+    return {};
+  }
+  console.debug('Prompt names:', idNameMap);
+  return idNameMap;
 });
 
 const quantity = computed(() => getQuantity(props.sabFood.food));
@@ -241,7 +264,7 @@ const promptI18n = computed(() => ({
   serving: serving.value,
   quantity: servingQuantity.value,
   leftovers: leftovers.value,
-  ...translatePrompt(['hadWith', 'noAddedFoods', 'same', 'notSame', 'some']),
+  ...translatePrompt(['hadWith', 'noAddedFoods', 'same', 'notSame']),
 }));
 
 onMounted(async () => {
@@ -267,7 +290,6 @@ onMounted(async () => {
   sabOptions.value = {
     serving: true,
     leftovers: true,
-    // noAddedFoods: true,
     quantity: true,
     customPromptAnswers: true,
   };

--- a/apps/survey/src/components/prompts/standard/SameAsBeforePrompt.vue
+++ b/apps/survey/src/components/prompts/standard/SameAsBeforePrompt.vue
@@ -119,11 +119,21 @@
               <v-divider />
               <v-list-item v-for="(answer, answerIdx) in customPromptAnswer" :key="answerIdx" class="ps-0" density="compact">
                 <template #prepend>
-                  <v-icon icon="fas fa-caret-right" />
+                  <v-icon icon="fas fa-check" />
                 </template>
                 <v-list-item-title>{{ answer }}</v-list-item-title>
               </v-list-item>
             </div>
+          </v-list>
+          <v-list v-else class="px-4" color="grey-lighten-4">
+            <v-list-item class="ps-0" density="compact">
+              <template #prepend>
+                <v-icon icon="fas fa-caret-right" />
+              </template>
+              <v-list-item-title>
+                {{ promptI18n.none }}
+              </v-list-item-title>
+            </v-list-item>
           </v-list>
         </v-list>
       </v-card>
@@ -338,7 +348,7 @@ const promptI18n = computed(() => ({
   serving: serving.value,
   quantity: servingQuantity.value,
   leftovers: leftovers.value,
-  ...translatePrompt(['hadWith', 'noAddedFoods', 'same', 'notSame', 'details', 'hadQuantity', 'characteristics']),
+  ...translatePrompt(['hadWith', 'noAddedFoods', 'same', 'notSame', 'details', 'hadQuantity', 'characteristics', 'none']),
 }));
 
 onMounted(async () => {

--- a/apps/survey/src/components/prompts/standard/SameAsBeforePrompt.vue
+++ b/apps/survey/src/components/prompts/standard/SameAsBeforePrompt.vue
@@ -3,7 +3,27 @@
     <v-card-text class="pt-2 d-flex">
       <v-card v-if="showSABcard" class="border flat width=100%">
         <v-list v-if="serving || quantity || showLeftovers" class="px-4" color="grey-lighten-4">
-          <v-list-subheader>{{ translate(sabFood.food.data.localName) }}</v-list-subheader>
+          <div class="d-flex align-center">
+            <v-list-subheader class="flex-grow-1">
+              {{ promptI18n.hadQuantity }}
+            </v-list-subheader>
+            <div class="align-right">
+              <v-radio-group
+                v-model="sabOptions.portionSize"
+                :hide-details="true"
+                :inline="true"
+              >
+                <v-radio
+                  :label="$t('common.action.yes')"
+                  :value="true"
+                />
+                <v-radio
+                  :label="$t('common.action.no')"
+                  :value="false"
+                />
+              </v-radio-group>
+            </div>
+          </div>
           <v-divider />
           <v-list-item v-if="serving" class="ps-0" density="compact">
             <v-list-item-title>
@@ -29,25 +49,29 @@
               <v-list-item-title>{{ promptI18n.leftovers }}</v-list-item-title>
             </v-list-item>
           </div>
-          <v-list-item class="ps-0" density="compact">
-            <v-radio-group
-              v-model="sabOptions.portionSize"
-              :hide-details="true"
-              :inline="true"
-            >
-              <v-radio
-                :label="$t('common.action.yes')"
-                :value="true"
-              />
-              <v-radio
-                :label="$t('common.action.no')"
-                :value="false"
-              />
-            </v-radio-group>
-          </v-list-item>
         </v-list>
         <v-list class="px-4" color="grey-lighten-4">
-          <v-list-subheader>{{ promptI18n.hadWith }}</v-list-subheader>
+          <div class="d-flex align-center">
+            <v-list-subheader class="flex-grow-1">
+              {{ promptI18n.hadWith }}
+            </v-list-subheader>
+            <div class="align-right">
+              <v-radio-group
+                v-model="sabOptions.linkedFoods"
+                :hide-details="true"
+                :inline="true"
+              >
+                <v-radio
+                  :label="$t('common.action.yes')"
+                  :value="true"
+                />
+                <v-radio
+                  :label="$t('common.action.no')"
+                  :value="false"
+                />
+              </v-radio-group>
+            </div>
+          </div>
           <v-divider />
           <v-list-item v-if="!linkedFoods.length" class="ps-0" density="compact">
             <template #prepend>
@@ -65,56 +89,55 @@
               {{ linkedFood.text ? linkedFood.text : '' }}
             </v-list-item>
           </template>
-          <v-radio-group
-            v-model="sabOptions.linkedFoods"
-            :hide-details="true"
-            :inline="true"
-          >
-            <v-radio
-              :label="$t('common.action.yes')"
-              :value="true"
-            />
-            <v-radio
-              :label="$t('common.action.no')"
-              :value="false"
-            />
-          </v-radio-group>
         </v-list>
-        <v-list v-if="customPromptAnswers && Object.keys(customPromptAnswers).length > 0" class="px-4" color="grey-lighten-4">
-          <div v-for="(customPromptAnswer, index) in customPromptAnswers" :key="index">
-            <v-list-subheader>{{ promptNames[index] || '' }}</v-list-subheader>
-            <v-divider />
-            <v-list-item v-for="(answer, answerIdx) in customPromptAnswer" :key="answerIdx" class="ps-0" density="compact">
-              <template #prepend>
-                <v-icon icon="fas fa-caret-right" />
-              </template>
-              <v-list-item-title>{{ answer }}</v-list-item-title>
-            </v-list-item>
+        <v-list class="px-4" color="grey-lighten-4">
+          <div class="d-flex align-center">
+            <v-list-subheader class="flex-grow-1">
+              {{ promptI18n.characteristics }}
+            </v-list-subheader>
+            <div class="align-right">
+              <v-radio-group
+                v-model="sabOptions.customPromptAnswers"
+                :hide-details="true"
+                :inline="true"
+              >
+                <v-radio
+                  :label="$t('common.action.yes')"
+                  :value="true"
+                />
+                <v-radio
+                  :label="$t('common.action.no')"
+                  :value="false"
+                />
+              </v-radio-group>
+            </div>
           </div>
-          <v-radio-group
-            v-model="sabOptions.customPromptAnswers"
-            :hide-details="true"
-            :inline="true"
-          >
-            <v-radio
-              :label="$t('common.action.yes')"
-              :value="true"
-            />
-            <v-radio
-              :label="$t('common.action.no')"
-              :value="false"
-            />
-          </v-radio-group>
+          <v-divider />
+          <v-list v-if="customPromptAnswers && Object.keys(customPromptAnswers).length > 0" class="px-4" color="grey-lighten-4">
+            <div v-for="(customPromptAnswer, index) in customPromptAnswers" :key="index">
+              <v-list-subheader>{{ promptNames[index] || '' }}</v-list-subheader>
+              <v-divider />
+              <v-list-item v-for="(answer, answerIdx) in customPromptAnswer" :key="answerIdx" class="ps-0" density="compact">
+                <template #prepend>
+                  <v-icon icon="fas fa-caret-right" />
+                </template>
+                <v-list-item-title>{{ answer }}</v-list-item-title>
+              </v-list-item>
+            </div>
+          </v-list>
         </v-list>
       </v-card>
     </v-card-text>
     <template #actions>
       <template v-if="!showSABcard">
-        <v-btn :title="promptI18n.notSame" variant="text" @click.stop="action('notSame')">
+        <v-btn :title="promptI18n.notSame" @click.stop="action('notSame')">
           <v-icon icon="$no" start /> {{ promptI18n.notSame }}
         </v-btn>
-        <v-btn :title="promptI18n.same" @click.stop="showSABcard = !showSABcard">
-          <v-icon icon="$add" start /> {{ promptI18n.same }}
+        <v-btn :title="promptI18n.same" @click.stop="onSame">
+          <v-icon icon="$yes" start /> {{ promptI18n.same }}
+        </v-btn>
+        <v-btn :title="promptI18n.details" variant="flat" @click.stop="showSABcard = !showSABcard">
+          <v-icon icon="$info" start /> {{ promptI18n.details }}
         </v-btn>
       </template>
       <template v-else>
@@ -125,16 +148,22 @@
     </template>
     <template #nav-actions>
       <template v-if="!showSABcard">
-        <v-btn color="primary" :title="promptI18n.notSame" variant="text" @click.stop="action('notSame')">
+        <v-btn color="primary" :title="promptI18n.notSame" @click.stop="action('notSame')">
           <span class="text-overline font-weight-medium">
             {{ promptI18n.notSame }}</span>
           <v-icon class="pb-1" icon="$no" />
         </v-btn>
         <v-divider vertical />
-        <v-btn color="primary" :title="promptI18n.same" @click.stop="showSABcard = !showSABcard">
+        <v-btn color="primary" :title="promptI18n.same" @click.stop="onSame">
           <span class="text-overline font-weight-medium">
             {{ promptI18n.same }}</span>
-          <v-icon class="pb-1" icon="$add" />
+          <v-icon class="pb-1" icon="$yes" />
+        </v-btn>
+        <v-divider vertical />
+        <v-btn color="primary" :title="promptI18n.details" @click.stop="showSABcard = !showSABcard">
+          <span class="text-overline font-weight-medium">
+            {{ promptI18n.details }}</span>
+          <v-icon class="pb-1" icon="$info" />
         </v-btn>
       </template>
       <template v-else>
@@ -260,7 +289,8 @@ const customPromptAnswers = computed(() => {
       const prompt = foods.find(item => item.id === key);
       const label = prompt && Array.isArray(value) && 'options' in prompt && prompt?.options?.[locale.value]
         ? value.map(v =>
-            prompt.options[locale.value].find(option => option.value === v)?.label ?? v,
+            (prompt.options[locale.value].find(option => option.value === v)?.shortLabel
+              || prompt.options[locale.value].find(option => option.value === v)?.label) ?? v,
           )
         : [];
       return [key, label];
@@ -309,7 +339,7 @@ const promptI18n = computed(() => ({
   serving: serving.value,
   quantity: servingQuantity.value,
   leftovers: leftovers.value,
-  ...translatePrompt(['hadWith', 'noAddedFoods', 'same', 'notSame']),
+  ...translatePrompt(['hadWith', 'noAddedFoods', 'same', 'notSame', 'details', 'hadQuantity', 'characteristics']),
 }));
 
 onMounted(async () => {

--- a/apps/survey/src/components/prompts/standard/SameAsBeforePrompt.vue
+++ b/apps/survey/src/components/prompts/standard/SameAsBeforePrompt.vue
@@ -1,20 +1,19 @@
 <template>
   <card-layout v-bind="{ food, meal, prompt, section, isValid, sabOptions }" @action="action">
     <v-card-text class="pt-2 d-flex">
-      <v-card border flat width="100%">
-        <v-list class="px-4" color="grey-lighten-4">
+      <v-card v-if="showSABcard" class="border flat width=100%">
+        <v-list v-if="serving || quantity || showLeftovers" class="px-4" color="grey-lighten-4">
           <v-list-subheader>{{ translate(sabFood.food.data.localName) }}</v-list-subheader>
           <v-divider />
-          <v-list-item class="ps-0" density="compact">
-            <v-checkbox
-              v-model="sabOptions.serving"
-              class="custom-checkbox"
-              density="compact"
-              :label="promptI18n.serving"
-              :value="true"
-            />
+          <v-list-item v-if="serving" class="ps-0" density="compact">
+            <v-list-item-title>
+              {{ promptI18n.serving }}
+            </v-list-item-title>
+            <template #prepend>
+              <v-icon icon="fas fa-caret-right" />
+            </template>
           </v-list-item>
-          <v-list-item v-if="quantity > 1" class="ps-0" density="compact">
+          <v-list-item v-if="quantity" class="ps-0" density="compact">
             <template #prepend>
               <v-icon icon="fas fa-caret-right" />
             </template>
@@ -51,13 +50,12 @@
           <v-list-subheader>{{ promptI18n.hadWith }}</v-list-subheader>
           <v-divider />
           <v-list-item v-if="!linkedFoods.length" class="ps-0" density="compact">
-            <v-checkbox
-              v-model="sabOptions.noAddedFoods"
-              class="custom-checkbox"
-              density="compact"
-              :label="promptI18n.noAddedFoods"
-              :value="true"
-            />
+            <template #prepend>
+              <v-icon icon="fas fa-caret-right" />
+            </template>
+            <v-list-item-title>
+              {{ promptI18n.noAddedFoods }}
+            </v-list-item-title>
           </v-list-item>
           <template v-if="linkedFoods.length">
             <v-list-item v-for="linkedFood in linkedFoods" :key="linkedFood.id" class="ps-0" density="compact">
@@ -111,36 +109,42 @@
       </v-card>
     </v-card-text>
     <template #actions>
-      <v-btn
-        :title="promptI18n.notSame"
-        @click.stop="action('notSame')"
-      >
-        <v-icon icon="$no" start />
-        {{ promptI18n.notSame }}
-      </v-btn>
-      <v-btn
-        :title="promptI18n.same"
-        variant="text"
-        @click.stop="onSame"
-      >
-        <v-icon icon="$yes" start />
-        {{ promptI18n.same }}
-      </v-btn>
+      <template v-if="!showSABcard">
+        <v-btn :title="promptI18n.notSame" variant="text" @click.stop="action('notSame')">
+          <v-icon icon="$no" start /> {{ promptI18n.notSame }}
+        </v-btn>
+        <v-btn :title="promptI18n.same" @click.stop="showSABcard = !showSABcard">
+          <v-icon icon="$add" start /> {{ promptI18n.same }}
+        </v-btn>
+      </template>
+      <template v-else>
+        <v-btn block color="primary" :title="$t('common.action.continue')" variant="flat" @click.stop="onSame">
+          <v-icon icon="$next" start /> {{ $t('common.action.continue') }}
+        </v-btn>
+      </template>
     </template>
     <template #nav-actions>
-      <v-btn color="primary" :title="$t('common.action.no')" variant="text" @click.stop="action('notSame')">
-        <span class="text-overline font-weight-medium">
-          {{ $t('common.action.no') }}
-        </span>
-        <v-icon class="pb-1" icon="$no" />
-      </v-btn>
-      <v-divider vertical />
-      <v-btn color="primary" title="$t('common.action.yes')" variant="text" @click.stop="onSame">
-        <span class="text-overline font-weight-medium">
-          {{ $t('common.action.continue') }}
-        </span>
-        <v-icon class="pb-1" icon="$yes" />
-      </v-btn>
+      <template v-if="!showSABcard">
+        <v-btn color="primary" :title="promptI18n.notSame" variant="text" @click.stop="action('notSame')">
+          <span class="text-overline font-weight-medium">
+            {{ promptI18n.notSame }}</span>
+          <v-icon class="pb-1" icon="$no" />
+        </v-btn>
+        <v-divider vertical />
+        <v-btn color="primary" :title="promptI18n.same" @click.stop="showSABcard = !showSABcard">
+          <span class="text-overline font-weight-medium">
+            {{ promptI18n.same }}</span>
+          <v-icon class="pb-1" icon="$add" />
+        </v-btn>
+      </template>
+      <template v-else>
+        <v-btn block color="primary" title="$t('common.action.continue')" variant="flat" @click.stop="onSame">
+          <span class="text-overline font-weight-medium">
+            {{ $t('common.action.continue') }}
+          </span>
+          <v-icon class="pb-1" icon="$next" />
+        </v-btn>
+      </template>
     </template>
   </card-layout>
 </template>
@@ -170,6 +174,7 @@ const emit = defineEmits(['action', 'update:modelValue', 'update:sabOptions']);
 // Reactive state for "options"
 const sabOptions = ref<Record<string, any>>({});
 
+const showSABcard = ref(false); // New reactive state for showing/hiding card text
 const { i18n: { t, locale }, translate } = useI18n();
 const { action, translatePrompt, type } = usePromptUtils(props, { emit });
 const { standardUnitRefs, resolveStandardUnits } = useStandardUnits();

--- a/apps/survey/src/components/prompts/standard/SameAsBeforePrompt.vue
+++ b/apps/survey/src/components/prompts/standard/SameAsBeforePrompt.vue
@@ -202,12 +202,11 @@ const emit = defineEmits(['action', 'update:modelValue', 'update:sabOptions']);
 
 // Reactive state for "options"
 const sabOptions = ref<Record<string, any>>({});
-
-const showSABcard = ref(false); // New reactive state for showing/hiding card text
 const { i18n: { t, locale }, translate } = useI18n();
 const { action, translatePrompt, type } = usePromptUtils(props, { emit });
 const { standardUnitRefs, resolveStandardUnits } = useStandardUnits();
 const survey = useSurvey();
+const showSABcard = ref(survey.foodPrompts.find(item => item.component === 'same-as-before-prompt')?.skipToSAB === true);
 
 const isDrink = computed(() => props.sabFood.food.data.categories.includes('DRNK'));
 const isValid = true;

--- a/apps/survey/src/components/prompts/standard/SameAsBeforePrompt.vue
+++ b/apps/survey/src/components/prompts/standard/SameAsBeforePrompt.vue
@@ -115,8 +115,6 @@
           <v-divider />
           <v-list v-if="customPromptAnswers && Object.keys(customPromptAnswers).length > 0" class="px-4" color="grey-lighten-4">
             <div v-for="(customPromptAnswer, index) in customPromptAnswers" :key="index">
-              <v-list-subheader>{{ promptNames[index] || '' }}</v-list-subheader>
-              <v-divider />
               <v-list-item v-for="(answer, answerIdx) in customPromptAnswer" :key="answerIdx" class="ps-0" density="compact">
                 <template #prepend>
                   <v-icon icon="fas fa-check" />
@@ -310,18 +308,6 @@ const customPromptAnswers = computed(() => {
           : [prompt_id, [getLabel(options as string)]];
       }),
   );
-});
-
-const promptNames = computed(() => {
-  const foods = survey.parameters?.surveyScheme.prompts.meals.foods;
-  if (!foods) {
-    console.debug('No custom prompt names found');
-    return {};
-  }
-  return foods.reduce<Record<string, string>>((acc, item) => {
-    acc[item.id] = item.i18n?.name?.[locale.value] || item.i18n?.name?.en || '';
-    return acc;
-  }, {});
 });
 
 const quantity = computed(() => getQuantity(props.sabFood.food));

--- a/apps/survey/src/components/prompts/standard/SameAsBeforePrompt.vue
+++ b/apps/survey/src/components/prompts/standard/SameAsBeforePrompt.vue
@@ -54,19 +54,23 @@
             />
           </v-list-item>
         </v-list>
-        <!-- <v-list v-if="customPromptAnswers.length" class="px-4" color="grey-lighten-4">
-          <v-list-subheader>Please select your preferences</v-list-subheader>
+        <v-list v-if="customPromptAnswers.length" class="px-4" color="grey-lighten-4">
+          <v-list-subheader>Further information</v-list-subheader>
           <v-divider />
           <v-list-item v-for="(answer, index) in customPromptAnswers" :key="index" class="ps-0" density="compact">
-            <v-checkbox
-              v-model="options[index]"
-              class="custom-checkbox"
-              density="compact"
-              :label="String(answer)"
-              :value="answer"
-            />
+            <template #prepend>
+              <v-icon icon="fas fa-caret-right" />
+            </template>
+            <v-list-item-title>{{ answer }}</v-list-item-title>
           </v-list-item>
-        </v-list> -->
+          <v-checkbox
+            v-model="sabOptions.customPromptAnswers"
+            class="custom-checkbox"
+            density="compact"
+            :label="promptI18n.same"
+            :value="true"
+          />
+        </v-list>
       </v-card>
     </v-card-text>
     <template #actions>
@@ -203,10 +207,10 @@ const linkedFoods = computed(() =>
   }),
 );
 
-// const customPromptAnswers = computed(() => {
-//   const answers = props.sabFood.food.customPromptAnswers?.['sab-checkbox-list-prompt'];
-//   return Array.isArray(answers) ? answers.map(answer => answer) : [];
-// });
+const customPromptAnswers = computed(() => {
+  const answers = props.sabFood.food.customPromptAnswers?.['sab-checkbox-list-prompt'];
+  return Array.isArray(answers) ? answers.map(answer => answer) : [];
+});
 
 const quantity = computed(() => getQuantity(props.sabFood.food));
 const serving = computed(() => {
@@ -265,6 +269,7 @@ onMounted(async () => {
     leftovers: true,
     // noAddedFoods: true,
     quantity: true,
+    customPromptAnswers: true,
   };
   // Set each linked food checkbox to checked by default
   if (props.sabFood.food.linkedFoods?.length) {

--- a/apps/survey/src/stores/survey.ts
+++ b/apps/survey/src/stores/survey.ts
@@ -639,6 +639,7 @@ export const useSurvey = defineStore('survey', {
       const food = findFood(this.data.meals, data.foodId);
 
       food.customPromptAnswers[data.promptId] = data.answer;
+      this.saveSameAsBefore(data.foodId);
     },
 
     addFoodFlag(foodId: string, flag: FoodFlag | FoodFlag[]) {

--- a/apps/survey/src/util/meal-food.ts
+++ b/apps/survey/src/util/meal-food.ts
@@ -1,5 +1,8 @@
+import type { Prompt } from '@intake24/common/prompts';
 import type { FoodState, MealState, Selection, SurveyState } from '@intake24/common/surveys';
 import { randomString } from '@intake24/common/util';
+import { evaluateCondition } from '@intake24/survey/dynamic-recall/prompt-manager';
+import type { SurveyStore } from '@intake24/survey/stores';
 import type { FoodIndex, MealFoodIndex } from '@intake24/survey/stores/survey';
 
 // Helper to generate unique id for each meal/food with same length
@@ -190,4 +193,56 @@ export function flattenFoods(foods: FoodState[]): FoodState[] {
   }
 
   return result;
+}
+
+/**
+ * Check if a prompt's custom conditions are met for the given food
+ */
+function checkPromptCustomConditions(store: SurveyStore, mealState: MealState, foodState: FoodState, prompt: Prompt): boolean {
+  try {
+    if (prompt.conditions.length === 0)
+      return true;
+
+    return prompt.conditions.reduce((acc, condition, index) => {
+      const result = evaluateCondition(condition, store, mealState, foodState, `prompt conditions (${prompt.id})`);
+
+      if (index === 0)
+        return result;
+
+      if (condition.orPrevious)
+        return acc || result;
+
+      // short-circuit if acc is already false
+      return acc ? result : false;
+    }, true);
+  }
+  catch (e) {
+    console.error(`Invalid prompt condition`, e);
+    return false;
+  }
+}
+
+export function getIncompleteCustomPrompts(store: SurveyStore, meal: MealState, food: FoodState, foodPrompts: Prompt[]): Prompt[] {
+  return foodPrompts
+    .filter(prompt =>
+      prompt.type === 'custom' && prompt.id !== 'no-more-information-prompt-foods',
+    )
+    .filter(prompt =>
+      // Only prompts that apply to this food (conditions are met)
+      checkPromptCustomConditions(store, meal, food, prompt),
+    )
+    .filter((prompt) => {
+      // Only prompts that are not answered or have empty answers
+      const answer = food.customPromptAnswers[prompt.id];
+      return answer === undefined
+        || answer === null
+        || (typeof answer === 'object' && answer !== null && Object.keys(answer).length === 0);
+    });
+}
+
+/**
+ * Check if all applicable custom prompts for a food are complete
+ */
+export function customPromptComplete(store: SurveyStore, meal: MealState, food: FoodState, foodPrompts: Prompt[]): boolean {
+  return getIncompleteCustomPrompts(store, meal, food, foodPrompts).length === 0;
 }

--- a/packages/common/src/prompts/prompts.ts
+++ b/packages/common/src/prompts/prompts.ts
@@ -404,6 +404,7 @@ const reviewConfirmPrompt = baseStandardPrompt.extend({
 
 const sameAsBeforePrompt = baseStandardPrompt.extend({
   component: z.literal('same-as-before-prompt'),
+  skipToSAB: z.boolean().optional(),
 });
 
 const sleepSchedulePrompt = baseStandardPrompt.merge(timePicker).extend({

--- a/packages/common/src/types/common.ts
+++ b/packages/common/src/types/common.ts
@@ -76,6 +76,7 @@ export function listOption<T extends z.ZodTypeAny = z.ZodString>(valueSchema?: T
   return z.object({
     id: z.number().optional(),
     label: z.string().min(1).max(256),
+    shortLabel: z.string().min(1).max(256).optional(),
     value: valueSchema ?? z.string().min(1).max(256),
     exclusive: z.boolean().optional(),
     selected: z.boolean().optional(),

--- a/packages/i18n/src/admin/en/common.json
+++ b/packages/i18n/src/admin/en/common.json
@@ -94,6 +94,7 @@
     "key": "Key",
     "label": "Label",
     "value": "Value",
+    "shortLabel": "Short Label",
     "exclusive": "Exclusive",
     "selected": "Selected"
   },

--- a/packages/i18n/src/admin/en/common.json
+++ b/packages/i18n/src/admin/en/common.json
@@ -95,7 +95,6 @@
     "label": "Label",
     "shortLabel": "Short label",
     "value": "Value",
-    "shortLabel": "Short Label",
     "exclusive": "Exclusive",
     "selected": "Selected"
   },

--- a/packages/i18n/src/admin/en/common.json
+++ b/packages/i18n/src/admin/en/common.json
@@ -93,6 +93,7 @@
     "remove": "Remove option",
     "key": "Key",
     "label": "Label",
+    "shortLabel": "Short label",
     "value": "Value",
     "shortLabel": "Short Label",
     "exclusive": "Exclusive",

--- a/packages/i18n/src/admin/en/survey-schemes.json
+++ b/packages/i18n/src/admin/en/survey-schemes.json
@@ -653,7 +653,8 @@
     },
     "same-as-before-prompt": {
       "title": "Same as before",
-      "subtitle": "Ask if food was same as before"
+      "subtitle": "Ask if food was same as before",
+      "skipToSAB": "Skip the 'No/Yes/Display Details' screen"
     },
     "sleep-schedule-prompt": {
       "title": "Sleep schedule",

--- a/packages/i18n/src/admin/fr/common.json
+++ b/packages/i18n/src/admin/fr/common.json
@@ -91,6 +91,7 @@
     "key": "Key",
     "label": "Libellé",
     "value": "Valeur",
+    "shortLabel": "Libellé court",
     "exclusive": "Exclusive",
     "selected": "Selected"
   },

--- a/packages/i18n/src/admin/fr/common.json
+++ b/packages/i18n/src/admin/fr/common.json
@@ -90,8 +90,8 @@
     "remove": "Supprimer l'option",
     "key": "Key",
     "label": "Libellé",
-    "value": "Valeur",
     "shortLabel": "Libellé court",
+    "value": "Valeur",
     "exclusive": "Exclusive",
     "selected": "Selected"
   },

--- a/packages/i18n/src/admin/fr/survey-schemes.json
+++ b/packages/i18n/src/admin/fr/survey-schemes.json
@@ -649,7 +649,9 @@
     },
     "same-as-before-prompt": {
       "title": "Comme précédemment",
-      "subtitle": "Demander si l'aliment était tel que précédemment"
+      "subtitle": "Demander si l'aliment était tel que précédemment",
+      "skipToSAB": "Passer l'écran 'Non/Oui/Afficher les détails'"
+
     },
     "sleep-schedule-prompt": {
       "title": "Sleep schedule",

--- a/packages/i18n/src/admin/fr/survey-schemes.json
+++ b/packages/i18n/src/admin/fr/survey-schemes.json
@@ -651,7 +651,6 @@
       "title": "Comme précédemment",
       "subtitle": "Demander si l'aliment était tel que précédemment",
       "skipToSAB": "Passer l'écran 'Non/Oui/Afficher les détails'"
-
     },
     "sleep-schedule-prompt": {
       "title": "Sleep schedule",

--- a/packages/i18n/src/shared/en/prompts.json
+++ b/packages/i18n/src/shared/en/prompts.json
@@ -304,8 +304,8 @@
     },
     "hadWith": "Had it with:",
     "noAddedFoods": "Nothing added (e.g. milk, sugar, sauces)",
-    "same": "Yes, I had the same",
-    "notSame": "No, I had a different one"
+    "same": "Yes, it's similar",
+    "notSame": "No, it's different"
   },
   "sleepSchedule": {
     "name": "Sleep schedule",

--- a/packages/i18n/src/shared/en/prompts.json
+++ b/packages/i18n/src/shared/en/prompts.json
@@ -308,7 +308,8 @@
     "notSame": "No",
     "details": "Display details",
     "hadQuantity": "Quantity",
-    "characteristics": "Characteristics"
+    "characteristics": "Characteristics",
+    "none": "None"
   },
   "sleepSchedule": {
     "name": "Sleep schedule",

--- a/packages/i18n/src/shared/en/prompts.json
+++ b/packages/i18n/src/shared/en/prompts.json
@@ -304,7 +304,7 @@
     },
     "hadWith": "Had it with:",
     "noAddedFoods": "Nothing added (e.g. milk, sugar, sauces)",
-    "same": "Yes, checked details are same",
+    "same": "Continue",
     "notSame": "No, it's different"
   },
   "sleepSchedule": {

--- a/packages/i18n/src/shared/en/prompts.json
+++ b/packages/i18n/src/shared/en/prompts.json
@@ -304,7 +304,7 @@
     },
     "hadWith": "Had it with:",
     "noAddedFoods": "Nothing added (e.g. milk, sugar, sauces)",
-    "same": "Continue",
+    "same": "Yes, it's the same",
     "notSame": "No, it's different"
   },
   "sleepSchedule": {

--- a/packages/i18n/src/shared/en/prompts.json
+++ b/packages/i18n/src/shared/en/prompts.json
@@ -304,7 +304,7 @@
     },
     "hadWith": "Had it with:",
     "noAddedFoods": "Nothing added (e.g. milk, sugar, sauces)",
-    "same": "Yes, it's similar",
+    "same": "Yes, checked details are same",
     "notSame": "No, it's different"
   },
   "sleepSchedule": {

--- a/packages/i18n/src/shared/en/prompts.json
+++ b/packages/i18n/src/shared/en/prompts.json
@@ -294,7 +294,7 @@
   "sameAsBefore": {
     "name": "Same as before",
     "text": "",
-    "description": "<p>Was this <strong>{food}</strong> the same as the one you had before?</p>",
+    "description": "<p>Was this <strong>{food}</strong> the same as <i>the most recent one</i> you had before?</p>",
     "serving": "{amount} serving size",
     "leftovers": "Left about {amount}",
     "quantity": "{quantity} servings",
@@ -304,8 +304,11 @@
     },
     "hadWith": "Had it with:",
     "noAddedFoods": "Nothing added (e.g. milk, sugar, sauces)",
-    "same": "Yes, it's the same",
-    "notSame": "No, it's different"
+    "same": "Yes",
+    "notSame": "No",
+    "details": "Display details",
+    "hadQuantity": "Quantity",
+    "characteristics": "Characteristics"
   },
   "sleepSchedule": {
     "name": "Sleep schedule",

--- a/packages/i18n/src/shared/fr/prompts.json
+++ b/packages/i18n/src/shared/fr/prompts.json
@@ -308,7 +308,8 @@
     "notSame": "Non",
     "details": "Les détails",
     "hadQuantity": "Quantité",
-    "characteristics": "Caractéristiques"
+    "characteristics": "Caractéristiques",
+    "none": "Aucune"
   },
   "sleepSchedule": {
     "name": "Sleep schedule",

--- a/packages/i18n/src/shared/fr/prompts.json
+++ b/packages/i18n/src/shared/fr/prompts.json
@@ -294,7 +294,7 @@
   "sameAsBefore": {
     "name": "Comme précédemment",
     "text": "",
-    "description": "<p>Est-ce que l'aliment <strong>{food}</strong> était le même que celui consommé précédemment?</p>",
+    "description": "<p>Est-ce que l'aliment <strong>{food}</strong> était la même que la dernière que vous avez mangée auparavant?</p>",
     "serving": "portion unitaire de {amount}",
     "leftovers": "restes de {amount}",
     "quantity": "{quantity} portions",
@@ -304,8 +304,11 @@
     },
     "hadWith": "Consommé avec :",
     "noAddedFoods": "Rien",
-    "same": "Continuer",
-    "notSame": "Non"
+    "same": "Oui",
+    "notSame": "Non",
+    "details": "Les détails",
+    "hadQuantity": "Quantité",
+    "characteristics": "Caractéristiques"
   },
   "sleepSchedule": {
     "name": "Sleep schedule",


### PR DESCRIPTION
This pull request is combined changes from [V4-1414](https://intake24.atlassian.net/browse/V4-1414) and [V4-1372](https://intake24.atlassian.net/browse/V4-1372), as they shared a change on admin tool seek to release altogether. 

### Highlights:
**V4-1372: Review panel enhancement**
1. (admin) Add `shortLabel` to Options in `radio-list-prompt`, `checkbox-list-prompt` and `yes-no-prompt` custom prompt.
2. (survey, admin) Add few wordings for French locale.
3. (survey) update review panel to properly showing short labels, and fallback to labels or values if not present.
4. (survey) add logics to check whether custom prompt is completed, and update the second green tick on review panel.

**V4-1414: Same-as-before enhancement**
1. (admin) Add `SkipToSAB` switch on `same-as-before` prompt to allow to choose the behaviour of SAB prompt.
2. (survey, admin) Add few wordings for French locale.
3. (survey) Facilitate more fine-grained choice before cloning food object in SAB prompt.
4. (survey) Display custom prompts status in SAB prompt using `shortLabel`. 

