### PR TITLE
feat(prompt-list): prompt editor subsections

### DIFF
--- a/apps/admin/src/components/prompts/list/prompt-list-item.vue
+++ b/apps/admin/src/components/prompts/list/prompt-list-item.vue
@@ -63,6 +63,29 @@
                 variant="outlined"
               />
             </confirm-dialog>
+            <confirm-dialog
+              color="info"
+              :label="$t('survey-schemes.prompts.subsections.change')"
+              max-width="450px"
+              @close="clearMoveToSubsection"
+              @confirm="changeSubsection"
+            >
+              <template #activator="{ props }">
+                <v-list-item link v-bind="props">
+                  <v-list-item-title>
+                    <v-icon icon="fas fa-exchange-alt" start />
+                    {{ $t('survey-schemes.prompts.subsections.change') }}
+                  </v-list-item-title>
+                </v-list-item>
+              </template>
+              <v-select
+                v-model="moveToSubsection"
+                hide-details="auto"
+                :items="moveSubsections"
+                :label="$t('survey-schemes.prompts.subsections.change')"
+                variant="outlined"
+              />
+            </confirm-dialog>
             <save-as-template-dialog
               v-if="can('survey-scheme-prompts:create') && !hasTemplate"
               :prompt="prompt"
@@ -104,7 +127,7 @@
 <script lang="ts" setup>
 import type { PropType } from 'vue';
 
-import type { MoveSection } from './prompt-list.vue';
+import type { MoveSection, MoveSubsection } from './prompt-list.vue';
 import type { Prompt } from '@intake24/common/prompts';
 
 import { deepEqual } from 'fast-equals';
@@ -139,16 +162,21 @@ const props = defineProps({
     type: Array as PropType<MoveSection[]>,
     default: () => [],
   },
+  moveSubsections: {
+    type: Array as PropType<MoveSubsection[]>,
+    default: () => [],
+  },
   templates: {
     type: Array as PropType<Prompt[]>,
     default: () => [],
   },
 });
 
-const emit = defineEmits(['promptCopy', 'promptEdit', 'promptMove', 'promptRemove', 'promptSync']);
+const emit = defineEmits(['promptCopy', 'promptEdit', 'promptMove', 'promptChangeSubsection', 'promptRemove', 'promptSync']);
 
 const contextMenu = ref(false);
 const moveToSection = ref<string | null>(null);
+const moveToSubsection = ref<number | null>(null);
 
 const isOverrideMode = computed(() => props.mode === 'override');
 const template = computed(() => props.templates.find(
@@ -184,6 +212,23 @@ function move() {
 
 function clearMoveToSection() {
   moveToSection.value = null;
+};
+
+function changeSubsection() {
+  if (moveToSubsection.value === null)
+    return;
+
+  emit('promptChangeSubsection', {
+    subsectionIndex: moveToSubsection.value,
+    index: props.index,
+    prompt: copyObject(props.prompt),
+  });
+
+  clearMoveToSubsection();
+};
+
+function clearMoveToSubsection() {
+  moveToSubsection.value = null;
 };
 
 function remove() {

--- a/apps/admin/src/components/prompts/list/prompt-list.vue
+++ b/apps/admin/src/components/prompts/list/prompt-list.vue
@@ -40,31 +40,126 @@
       </template>
     </v-expansion-panel-title>
     <v-expansion-panel-text>
-      <v-list class="list-border" lines="two">
-        <vue-draggable
-          v-model="prompts"
-          :animation="300"
-          handle=".drag-and-drop__handle"
+      <div v-if="!isOverrideMode" class="d-flex justify-end mb-3">
+        <v-btn
+          color="primary"
+          prepend-icon="$add"
+          size="small"
+          variant="outlined"
+          @click="addSubsection"
         >
-          <prompt-list-item
-            v-for="(prompt, index) in prompts"
-            :key="`${prompt.id}:${prompt.name}`"
-            v-bind="{
-              errors: errors.get(`prompts.${fullSection}.${index}.*`),
-              mode,
-              prompt,
-              index,
-              templates,
-            }"
-            :move-sections="moveSections(prompt)"
-            @prompt-copy="copy"
-            @prompt-edit="edit"
-            @prompt-move="move"
-            @prompt-remove="remove"
-            @prompt-sync="sync"
-          />
-        </vue-draggable>
-      </v-list>
+          {{ `${$t('survey-schemes.prompts.subsections.add')}` }}
+        </v-btn>
+      </div>
+
+      <vue-draggable
+        v-model="subsectionsState"
+        :animation="300"
+        handle=".prompt-subsection__handle"
+      >
+        <div
+          v-for="(subsection, subsectionIndex) in subsectionsState"
+          :key="subsectionKey(subsectionIndex)"
+          class="prompt-subsection mb-3"
+        >
+          <div class="prompt-subsection__title d-flex align-center px-3 py-2">
+            <v-avatar class="prompt-subsection__handle drag-and-drop__handle mr-3" icon="$handle" size="26" />
+            <span class="text-subtitle-2 font-weight-medium prompt-subsection__name mr-2">
+              {{ subsection.name }}
+            </span>
+            <v-spacer />
+            <v-btn
+              v-if="!isOverrideMode"
+              color="primary"
+              icon="$add"
+              size="x-small"
+              :title="$t('survey-schemes.prompts.create')"
+              @click.stop="create(subsectionIndex)"
+            />
+            <options-menu v-if="!isOverrideMode">
+              <template #activator="{ props: menuProps }">
+                <v-btn
+                  class="ms-2"
+                  color="primary"
+                  icon="$options"
+                  size="x-small"
+                  v-bind="menuProps"
+                />
+              </template>
+              <confirm-dialog
+                color="info"
+                :label="$t('survey-schemes.prompts.subsections.rename')"
+                max-width="450px"
+                @close="clearRenameSubsection"
+                @confirm="renameSubsection(subsectionIndex)"
+              >
+                <template #activator="{ props: dialogProps }">
+                  <v-list-item link v-bind="dialogProps" @click="startRenameSubsection(subsectionIndex)">
+                    <v-list-item-title>
+                      <v-icon icon="$edit" start />
+                      {{ `${$t('survey-schemes.prompts.subsections.rename')}` }}
+                    </v-list-item-title>
+                  </v-list-item>
+                </template>
+                <v-text-field
+                  v-model="subsectionNameDraft"
+                  :label="$t('common.name')"
+                  variant="outlined"
+                />
+              </confirm-dialog>
+            </options-menu>
+            <v-btn
+              v-if="!isOverrideMode && !subsection.prompts.length"
+              color="error"
+              icon="$delete"
+              size="x-small"
+              variant="text"
+              @click.stop="removeSubsection(subsectionIndex)"
+            />
+            <v-btn
+              color="secondary"
+              :icon="subsection.expanded ? '$expand' : '$collapse'"
+              size="x-small"
+              variant="text"
+              @click.stop="toggleSubsectionExpand(subsectionIndex)"
+            />
+          </div>
+
+          <v-expand-transition>
+            <div v-show="subsection.expanded">
+              <v-list class="list-border" lines="two">
+                <vue-draggable
+                  v-model="subsection.prompts"
+                  :animation="300"
+                  :group="{ name: `prompt-subsection-${section}` }"
+                  handle=".drag-and-drop__handle"
+                >
+                  <prompt-list-item
+                    v-for="(prompt, index) in subsection.prompts"
+                    :key="`${prompt.id}:${prompt.name}`"
+                    v-bind="{
+                      errors: errors.get(`prompts.${fullSection}.${globalIndex(subsectionIndex, index)}.*`),
+                      mode,
+                      prompt,
+                      index,
+                      templates,
+                    }"
+                    :move-sections="moveSections(prompt)"
+                    :move-subsections="subsectionOptions"
+                    @prompt-change-subsection="changeSubsection(subsectionIndex, $event)"
+                    @prompt-copy="copy(subsectionIndex, $event)"
+                    @prompt-edit="edit(subsectionIndex, $event)"
+                    @prompt-move="move(subsectionIndex, $event)"
+                    @prompt-remove="remove(subsectionIndex, $event)"
+                    @prompt-sync="sync(subsectionIndex, $event)"
+                  />
+                </vue-draggable>
+              </v-list>
+            </div>
+          </v-expand-transition>
+        </div>
+      </vue-draggable>
+
       <prompt-selector ref="selector" v-bind="{ mode, section, promptIds }" @save="save" />
     </v-expansion-panel-text>
   </v-expansion-panel>
@@ -76,7 +171,12 @@ import type { PropType } from 'vue';
 
 import type { ReturnUseErrors } from '@intake24/admin/composables';
 import type { SinglePrompt } from '@intake24/common/prompts';
-import type { MealSection, PromptSection, SurveyPromptSection } from '@intake24/common/surveys';
+import type {
+  MealSection,
+  PromptSection,
+  PromptSubsectionLayout,
+  SurveyPromptSection,
+} from '@intake24/common/surveys';
 
 import { deepEqual } from 'fast-equals';
 import { computed, ref, watch } from 'vue';
@@ -87,21 +187,32 @@ import { JsonEditorDialog } from '@intake24/admin/components/editors';
 import { promptSettings } from '@intake24/admin/components/prompts';
 import { isMealSection } from '@intake24/common/surveys';
 import { copy as copyObject } from '@intake24/common/util';
-import { useI18n } from '@intake24/ui';
+import { ConfirmDialog, useI18n } from '@intake24/ui';
 
 import PromptSelector from '../prompt-selector.vue';
 import LoadPromptDialog from './load-prompt-dialog.vue';
 import PromptListItem from './prompt-list-item.vue';
 
 export type MoveSection = { value: string; title: string };
+export type MoveSubsection = { value: number; title: string };
 
 export type PromptEvent = {
   index: number;
   prompt: SinglePrompt;
 };
 
+type PromptSubsection = {
+  name: string;
+  expanded: boolean;
+  prompts: SinglePrompt[];
+};
+
 export interface PromptMoveEvent extends PromptEvent {
   section: MealSection | SurveyPromptSection;
+}
+
+export interface PromptSubsectionMoveEvent extends PromptEvent {
+  subsectionIndex: number;
 }
 
 defineOptions({ name: 'PromptList' });
@@ -130,18 +241,23 @@ const props = defineProps({
     type: Array as PropType<SinglePrompt[]>,
     default: () => [],
   },
+  subsectionLayouts: {
+    type: Array as PropType<PromptSubsectionLayout[]>,
+    default: () => [],
+  },
   modelValue: {
     type: Array as PropType<SinglePrompt[]>,
     required: true,
   },
 });
 
-const emit = defineEmits(['update:modelValue', 'move']);
+const emit = defineEmits(['update:modelValue', 'update:subsectionLayouts', 'move']);
 
 const { i18n } = useI18n();
 
 const selector = ref<InstanceType<typeof PromptSelector>>();
-const prompts = ref(copyObject(props.modelValue));
+const pendingSubsectionIndex = ref<number | null>(null);
+const subsectionNameDraft = ref('');
 
 const isOverrideMode = computed(() => props.mode === 'override');
 const title = computed(() => i18n.t(
@@ -155,36 +271,151 @@ const subtitle = computed(() => i18n.t(
     : `survey-schemes.prompts.${props.section}.subtitle`,
 ));
 const fullSection = computed(() => isMealSection(props.section) ? `meals.${props.section}` : props.section);
+const subsectionsState = ref<PromptSubsection[]>(buildSubsections(copyObject(props.modelValue), copyObject(props.subsectionLayouts)));
+const prompts = computed<SinglePrompt[]>({
+  get: () => flattenSubsections(subsectionsState.value),
+  set: (value) => {
+    subsectionsState.value = buildSubsections(copyObject(value), copyObject(props.subsectionLayouts));
+  },
+});
+const subsectionOptions = computed<MoveSubsection[]>(() => subsectionsState.value.map((subsection, index) => ({
+  value: index,
+  title: subsection.name,
+})));
+
+function defaultSubsectionName(index: number) {
+  if (isOverrideMode.value) {
+    return i18n.t(`survey-schemes.overrides.prompts.subsectionName`);
+  }
+  const sectionTitle = i18n.t(`survey-schemes.prompts.${props.section}.title`);
+  const sectionBase = sectionTitle.replace('/\s+prompts$/i', '');
+
+  return `${sectionBase} ${index + 1}`;
+}
+
+function subsectionKey(index: number) {
+  return `${props.section}:${index}`;
+}
+
+function buildSubsections(prompts: SinglePrompt[], subsections: PromptSubsectionLayout[]): PromptSubsection[] {
+  if (isOverrideMode.value)
+    return [{ name: defaultSubsectionName(0), expanded: true, prompts: [...prompts] }];
+
+  if (!subsections.length)
+    return [{ name: defaultSubsectionName(0), expanded: true, prompts: [...prompts] }];
+
+  let offset = 0;
+  const items = subsections.map((item, index) => {
+    const size = Math.max(0, item.size || 0);
+    const subsectionPrompts = prompts.slice(offset, offset + size);
+    offset += size;
+
+    return {
+      name: item.name || defaultSubsectionName(index),
+      expanded: item.expanded ?? true,
+      prompts: subsectionPrompts,
+    };
+  });
+
+  if (offset < prompts.length)
+    items.push({ name: defaultSubsectionName(items.length), expanded: true, prompts: prompts.slice(offset) });
+
+  return items.length ? items : [{ name: defaultSubsectionName(0), expanded: true, prompts: [...prompts] }];
+}
+
+function flattenSubsections(subsections: PromptSubsection[]) {
+  return subsections.flatMap(subsection => subsection.prompts);
+}
+
+function serializedSubsections(subsections: PromptSubsection[]): PromptSubsectionLayout[] {
+  return subsections.map((subsection, index) => ({
+    id: subsectionKey(index),
+    size: subsection.prompts.length,
+    expanded: subsection.expanded,
+    name: subsection.name,
+  }));
+}
+
+function locate(subsectionIndex: number, index: number) {
+  const subsection = subsectionsState.value[subsectionIndex];
+  if (!subsection)
+    return;
+
+  return { subsection, index };
+}
+
+function globalIndex(subsectionIndex: number, index: number) {
+  let offset = 0;
+  for (let idx = 0; idx < subsectionsState.value.length; idx++) {
+    if (idx === subsectionIndex)
+      return offset + index;
+
+    offset += subsectionsState.value[idx].prompts.length;
+  }
+
+  return index;
+}
+
+function ensureSubsectionExists(targetSubsectionIndex?: number | null): PromptSubsection {
+  if (typeof targetSubsectionIndex === 'number') {
+    const item = subsectionsState.value[targetSubsectionIndex];
+    if (item)
+      return item;
+  }
+
+  if (!subsectionsState.value.length)
+    subsectionsState.value.push({ name: defaultSubsectionName(0), expanded: true, prompts: [] });
+
+  return subsectionsState.value.at(-1)!;
+};
 
 function clearErrors(index?: number) {
   props.errors.clear(typeof index === 'undefined' ? `prompts.${fullSection.value}.*` : `prompts.${fullSection.value}.${index}.*`);
 }
 
-function create() {
+function create(subsectionIndex?: number) {
   if (isOverrideMode.value)
     return;
 
-  selector.value?.create();
+  pendingSubsectionIndex.value = typeof subsectionIndex === 'number' ? subsectionIndex : null;
+  selector.value?.create?.();
 };
 
 function load(prompt: SinglePrompt) {
   clearErrors();
-  prompts.value.push(prompt);
+  ensureSubsectionExists().prompts.push(prompt);
 };
 
-function copy({ prompt, index }: PromptEvent) {
-  prompts.value.splice(index + 1, 0, { ...copyObject(prompt), id: `${prompt.id}-copy`, name: `${prompt.name} (copy)` });
+function copy(subsectionIndex: number, { prompt, index }: PromptEvent) {
+  const target = locate(subsectionIndex, index);
+  if (!target)
+    return;
+
+  target.subsection.prompts.splice(index + 1, 0, { ...copyObject(prompt), id: `${prompt.id}-copy`, name: `${prompt.name} (copy)` });
 };
 
-function edit({ prompt, index }: PromptEvent) {
-  const errors = props.errors.get(`prompts.${fullSection.value}.${index}.*`);
-  selector.value?.edit(index, prompt, errors);
+function edit(subsectionIndex: number, { prompt, index }: PromptEvent) {
+  const itemIndex = globalIndex(subsectionIndex, index);
+  const errors = props.errors?.get(`prompts.${fullSection.value}.${itemIndex}.*`);
+  selector.value?.edit?.(itemIndex, prompt, errors);
 };
 
 function save({ prompt, index }: PromptEvent) {
-  if (index === -1)
-    prompts.value.push(prompt);
-  else prompts.value.splice(index, 1, prompt);
+  if (index === -1) {
+    ensureSubsectionExists(pendingSubsectionIndex.value).prompts.push(prompt);
+    pendingSubsectionIndex.value = null;
+  }
+  else {
+    let offset = 0;
+    for (const subsection of subsectionsState.value) {
+      if (index < offset + subsection.prompts.length) {
+        subsection.prompts.splice(index - offset, 1, prompt);
+        break;
+      }
+
+      offset += subsection.prompts.length;
+    }
+  }
 
   clearErrors(index);
 };
@@ -198,44 +429,139 @@ function moveSections(prompt: SinglePrompt): MoveSection[] {
     }));
 };
 
-function move(event: PromptMoveEvent) {
+function move(subsectionIndex: number, event: PromptMoveEvent) {
   if (isOverrideMode.value)
     return;
 
-  emit('move', event);
-  prompts.value.splice(event.index, 1);
+  const target = locate(subsectionIndex, event.index);
+  if (!target)
+    return;
+
+  emit('move', { ...event, index: globalIndex(subsectionIndex, event.index) });
+  target.subsection.prompts.splice(event.index, 1);
 };
 
-function remove(index: number) {
-  clearErrors(index);
-  prompts.value.splice(index, 1);
+function changeSubsection(subsectionIndex: number, event: PromptSubsectionMoveEvent) {
+  if (isOverrideMode.value || subsectionIndex === event.subsectionIndex)
+    return;
+
+  const source = locate(subsectionIndex, event.index);
+  const target = subsectionsState.value[event.subsectionIndex];
+  if (!source || !target)
+    return;
+
+  const [prompt] = source.subsection.prompts.splice(event.index, 1);
+  if (!prompt)
+    return;
+
+  target.prompts.push(prompt);
 };
 
-function sync({ prompt, index }: PromptEvent) {
+function remove(subsectionIndex: number, index: number) {
+  const target = locate(subsectionIndex, index);
+  if (!target)
+    return;
+
+  clearErrors(globalIndex(subsectionIndex, index));
+  target.subsection.prompts.splice(index, 1);
+};
+
+function sync(subsectionIndex: number, { prompt, index }: PromptEvent) {
   if (isOverrideMode.value)
     return;
 
-  prompts.value.splice(index, 1, prompt);
+  const target = locate(subsectionIndex, index);
+  if (!target)
+    return;
+
+  target.subsection.prompts.splice(index, 1, prompt);
 };
+
+function addSubsection() {
+  subsectionsState.value.push({ name: defaultSubsectionName(subsectionsState.value.length), expanded: true, prompts: [] });
+}
+
+function removeSubsection(subsectionIndex: number) {
+  const subsection = subsectionsState.value[subsectionIndex];
+  if (!subsection || subsection.prompts.length)
+    return;
+
+  subsectionsState.value.splice(subsectionIndex, 1);
+}
+
+function toggleSubsectionExpand(subsectionIndex: number) {
+  const subsection = subsectionsState.value[subsectionIndex];
+  if (!subsection)
+    return;
+
+  subsection.expanded = !subsection.expanded;
+}
+
+function startRenameSubsection(subsectionIndex: number) {
+  const subsection = subsectionsState.value[subsectionIndex];
+  if (!subsection)
+    return;
+
+  subsectionNameDraft.value = subsection.name;
+}
+
+function renameSubsection(subsectionIndex: number) {
+  const subsection = subsectionsState.value[subsectionIndex];
+  if (!subsection)
+    return;
+
+  const name = subsectionNameDraft.value.trim();
+  if (!name)
+    return;
+
+  subsection.name = name;
+  clearRenameSubsection();
+}
+
+function clearRenameSubsection() {
+  subsectionNameDraft.value = '';
+}
 
 function update() {
-  emit('update:modelValue', prompts.value);
+  const prompts = flattenSubsections(subsectionsState.value);
+  if (!deepEqual(prompts, props.modelValue))
+    emit('update:modelValue', prompts);
+
+  const subsectionLayouts = serializedSubsections(subsectionsState.value);
+  if (!deepEqual(subsectionLayouts, props.subsectionLayouts))
+    emit('update:subsectionLayouts', subsectionLayouts);
 };
 
-watch(() => props.modelValue, (val) => {
-  if (deepEqual(val, prompts.value))
+function syncFromProps() {
+  if (deepEqual(props.modelValue, flattenSubsections(subsectionsState.value)) && deepEqual(props.subsectionLayouts, serializedSubsections(subsectionsState.value)))
     return;
 
-  prompts.value = [...val];
-});
+  subsectionsState.value = buildSubsections(copyObject(props.modelValue), copyObject(props.subsectionLayouts));
+}
 
-watch(prompts, (val) => {
-  if (deepEqual(val, props.modelValue))
-    return;
+watch(() => props.modelValue, syncFromProps, { deep: true });
+watch(() => props.subsectionLayouts, syncFromProps, { deep: true });
 
+watch(subsectionsState, () => {
   update();
 }, { deep: true });
 </script>
 
 <style lang="scss">
+.prompt-subsection {
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+  border-radius: 4px;
+}
+
+.prompt-subsection__title {
+  background: rgba(var(--v-theme-on-surface), 0.03);
+}
+
+.prompt-subsection__name {
+  max-width: 260px;
+}
+
+.prompt-subsection__handle {
+  cursor: grab;
+}
 </style>

--- a/apps/admin/src/views/survey-schemes/prompts/browse.vue
+++ b/apps/admin/src/views/survey-schemes/prompts/browse.vue
@@ -35,10 +35,12 @@
           step: index + 1,
           promptIds,
           templates,
+          subsectionLayouts: promptSubsectionLayouts(section),
           modelValue: isMealSection(section) ? data.prompts.meals[section] : data.prompts[section],
         }"
         @move="move"
         @update:model-value="updateItems(section, $event)"
+        @update:subsection-layouts="updateSubsectionLayouts(section, $event)"
       />
     </v-expansion-panels>
   </entry-layout>
@@ -48,7 +50,7 @@
 import type { SurveySchemeForm } from '../form.vue';
 import type { PromptMoveEvent } from '@intake24/admin/components/prompts/list/prompt-list.vue';
 import type { SinglePrompt } from '@intake24/common/prompts';
-import type { PromptSection, RecallPrompts } from '@intake24/common/surveys';
+import type { PromptSection, PromptSubsectionLayout, RecallPrompts } from '@intake24/common/surveys';
 import type { SurveySchemeEntry, SurveySchemeRefs } from '@intake24/common/types/http/admin';
 
 import { defineComponent, ref } from 'vue';
@@ -123,6 +125,17 @@ export default defineComponent({
 
     load(prompts: RecallPrompts) {
       this.data.prompts = { ...prompts };
+    },
+
+    promptSubsectionLayouts(section: PromptSection): PromptSubsectionLayout[] {
+      return this.data.prompts.ui?.subsectionLayouts?.[section]
+        ?? [];
+    },
+
+    updateSubsectionLayouts(section: PromptSection, subsectionLayouts: PromptSubsectionLayout[]) {
+      this.data.prompts.ui = this.data.prompts.ui || { subsectionLayouts: {} };
+      this.data.prompts.ui.subsectionLayouts = this.data.prompts.ui.subsectionLayouts || {};
+      this.data.prompts.ui.subsectionLayouts[section] = subsectionLayouts;
     },
 
     move(event: PromptMoveEvent) {

--- a/packages/common/src/surveys/scheme.ts
+++ b/packages/common/src/surveys/scheme.ts
@@ -52,6 +52,25 @@ export type FoodSection = (typeof foodSections)[number];
 export const promptSections = [...surveySections, ...mealSections] as const;
 export type PromptSection = (typeof promptSections)[number];
 
+export const promptSubsectionLayout = z.object({
+  id: z.string(),
+  size: z.coerce.number().int().min(0),
+  expanded: z.boolean(),
+  name: z.string(),
+});
+export type PromptSubsectionLayout = z.infer<typeof promptSubsectionLayout>;
+
+export const promptSubsectionLayouts = z.object({
+  preMeals: promptSubsectionLayout.array(),
+  preFoods: promptSubsectionLayout.array(),
+  foods: promptSubsectionLayout.array(),
+  postFoods: promptSubsectionLayout.array(),
+  foodsDeferred: promptSubsectionLayout.array(),
+  postMeals: promptSubsectionLayout.array(),
+  submission: promptSubsectionLayout.array(),
+}).partial();
+export type PromptSubsectionLayouts = z.infer<typeof promptSubsectionLayouts>;
+
 export const promptWithSection = basePrompt.extend({
   section: z.enum(promptSections),
 });
@@ -77,6 +96,9 @@ export const recallPrompts = z.object({
   }),
   postMeals: singlePrompt.array(),
   submission: singlePrompt.array(),
+  ui: z.object({
+    subsectionLayouts: promptSubsectionLayouts,
+  }).optional(),
 });
 export type RecallPrompts = z.infer<typeof recallPrompts>;
 
@@ -94,7 +116,9 @@ export const groupedRecallPrompts = z.object({
 export type GroupedRecallPrompts = z.infer<typeof groupedRecallPrompts>;
 
 export function flattenScheme(scheme: RecallPrompts): SinglePrompt[] {
-  return Object.values(scheme).reduce<SinglePrompt[]>((acc, prompts) => {
+  const { ui, ...promptSections } = scheme;
+
+  return Object.values(promptSections).reduce<SinglePrompt[]>((acc, prompts) => {
     // @ts-expect-error fix
     acc.push(...(Array.isArray(prompts) ? prompts : flattenScheme(prompts)));
     return acc;
@@ -102,7 +126,9 @@ export function flattenScheme(scheme: RecallPrompts): SinglePrompt[] {
 }
 
 export function flattenSchemeWithSection(scheme: RecallPrompts): PromptWithSection[] {
-  return Object.entries(scheme).reduce<PromptWithSection[]>((acc, [section, prompts]) => {
+  const { ui, ...promptSections } = scheme;
+
+  return Object.entries(promptSections).reduce<PromptWithSection[]>((acc, [section, prompts]) => {
     const items = Array.isArray(prompts)
       ? prompts.map(prompt => ({ ...prompt, section }))
       // @ts-expect-error fix

--- a/packages/i18n/src/admin/en/survey-schemes.json
+++ b/packages/i18n/src/admin/en/survey-schemes.json
@@ -249,7 +249,8 @@
     },
     "prompts": {
       "title": "Scheme prompts overrides",
-      "subtitle": "Override specific scheme prompt. Changes will get merged by Prompts ID."
+      "subtitle": "Override specific scheme prompt. Changes will get merged by Prompts ID.",
+      "subsectionName": "Overrides"
     },
     "settings": {
       "title": "Scheme settings overrides",
@@ -266,6 +267,11 @@
     "move": "Move prompt",
     "remove": "Remove prompt",
     "section": "Prompts section",
+    "subsections": {
+      "add": "Add subsection",
+      "change": "Change subsection",
+      "rename": "Rename subsection"
+    },
     "preMeals": {
       "title": "Pre-recall prompts",
       "subtitle": "General prompts asked before the dietary recall, including personal prompts and the initial instructions."

--- a/packages/i18n/src/admin/fr/survey-schemes.json
+++ b/packages/i18n/src/admin/fr/survey-schemes.json
@@ -245,7 +245,8 @@
     },
     "prompts": {
       "title": "Déroger à certaines invites de la configuration",
-      "subtitle": "Déroger à certaines invites spécifiques. Les changements seront fusionnés par identifiant d'invite."
+      "subtitle": "Déroger à certaines invites spécifiques. Les changements seront fusionnés par identifiant d'invite.",
+      "subsectionName": "Overrides"
     },
     "settings": {
       "title": "Scheme settings overrides",
@@ -262,6 +263,11 @@
     "move": "Déplacer l'invite",
     "remove": "Enlever l'invite",
     "section": "Section des invites",
+    "subsections": {
+      "add": "Add subsection",
+      "change": "Change subsection",
+      "rename": "Rename subsection"
+    },
     "preMeals": {
       "title": "Invites pré-rappel",
       "subtitle": "Invites générales affichées avant le rappel alimentaire, incluant des invites personnelles et les consignes initiales."


### PR DESCRIPTION
- Adds subsections to the survey-scheme prompts editor. This allows for easier management when schemes have a large number of prompts.
- Subsections can be created, deleted, and renamed.
- Subsections are draggable and can be rearranged. Prompts can also be dragged between subsections (within the same section)